### PR TITLE
Upd logic for _recalculate_homing_end

### DIFF
--- a/klippy/extras/load_cell_probe.py
+++ b/klippy/extras/load_cell_probe.py
@@ -403,7 +403,7 @@ class TapAnalysis(object):
         for move in moves:
             moves_out.append(TrapezoidalMove(move))
             # DEBUG: enable to see trapq contents
-            logging.info("trapq move: %s" % (moves_out[-1].to_dict(),))
+            # logging.info("trapq move: %s" % (moves_out[-1].to_dict(),))
         num_moves = len(moves_out)
         if num_moves < 5 or num_moves > 7:
             raise self.printer.command_error(

--- a/klippy/extras/load_cell_probe.py
+++ b/klippy/extras/load_cell_probe.py
@@ -378,18 +378,23 @@ class TapAnalysis(object):
 
     # adjust move_t of move 1 to match the toolhead position of move 2
     def _recalculate_homing_end(self):
-        #TODO: REVIEW: This takes some logical shortcuts, does it need to be
-        # more generalized? e.g. to all 3 axes?
-        homing_move = self.moves[-5]
-        halt_move = self.moves[-4]
         # acceleration should be 0! This is the 'coasting' move:
-        accel = homing_move.accel
-        if accel != 0.:
-            raise self.printer.command_error(
-                'Unexpected acceleration in coasting move')
+        homing_moves = [move for move in self.moves if (move.z_r == -1.0) & (move.accel == 0.0)]
+        num_homing_moves = len(homing_moves)
+        if num_homing_moves != 1:
+            raise self.printer.command_error("Expected to be only one 'coasting' move down in tap. Got %s" % (num_homing_moves, ))
+        homing_move = homing_moves[0]
+        if homing_move.start_v == 0.0:
+            raise self.printer.command_error("Homing move start_v = 0.0")
+
+        halt_moves = [move for move in self.moves if move.move_t == 0.0]
+        num_halt_moves = len(halt_moves)
+        if num_halt_moves != 1:
+            raise self.printer.command_error("Expected to be only one halt move in tap. Got %s" % (num_halt_moves, ))
+        halt_move = halt_moves[0]
+
         # how long did it take to get to end_z?
-        homing_move.move_t = abs(
-            (halt_move.start_z - homing_move.start_z) / homing_move.start_v)
+        homing_move.move_t = abs((halt_move.start_z - homing_move.start_z) / homing_move.start_v)
         return homing_move.print_time + homing_move.move_t
 
     def _extract_trapq(self, trapq):
@@ -400,9 +405,9 @@ class TapAnalysis(object):
             # DEBUG: enable to see trapq contents
             logging.info("trapq move: %s" % (moves_out[-1].to_dict(),))
         num_moves = len(moves_out)
-        if num_moves < 5 or num_moves > 6:
+        if num_moves < 5 or num_moves > 7:
             raise self.printer.command_error(
-                "Expected tap to be 5 to 6 moves long was %s" % (num_moves, ))
+                "Expected tap to be 5 to 7 moves long was %s" % (num_moves, ))
         return moves_out
 
     def analyze(self):

--- a/klippy/extras/load_cell_probe.py
+++ b/klippy/extras/load_cell_probe.py
@@ -1027,7 +1027,6 @@ class LoadCellPrinterProbe(probe.PrinterProbe):
         ppa = TapAnalysis(self.printer, samples, self.tap_filter)
         ppa.analyze()
         # broadcast tap event data:
-        logging.info("[LOGGING] ppa.analyze(): %s" % ppa.to_dict())
         self.wh_helper.send({'tap': ppa.to_dict()})
         self._was_bad_tap = True
         if ppa.is_valid:

--- a/klippy/extras/load_cell_probe.py
+++ b/klippy/extras/load_cell_probe.py
@@ -394,7 +394,6 @@ class TapAnalysis(object):
 
     def _extract_trapq(self, trapq):
         moves, _ = trapq.extract_trapq(self.time[0], self.time[-1])
-        logging.info("moves DEBUG: %s" % (moves))
         moves_out = []
         for move in moves:
             moves_out.append(TrapezoidalMove(move))
@@ -1023,6 +1022,7 @@ class LoadCellPrinterProbe(probe.PrinterProbe):
         ppa = TapAnalysis(self.printer, samples, self.tap_filter)
         ppa.analyze()
         # broadcast tap event data:
+        logging.info("[LOGGING] ppa.analyze(): %s" % ppa.to_dict())
         self.wh_helper.send({'tap': ppa.to_dict()})
         self._was_bad_tap = True
         if ppa.is_valid:

--- a/klippy/extras/load_cell_probe.py
+++ b/klippy/extras/load_cell_probe.py
@@ -394,6 +394,7 @@ class TapAnalysis(object):
 
     def _extract_trapq(self, trapq):
         moves, _ = trapq.extract_trapq(self.time[0], self.time[-1])
+        logging.info("moves DEBUG: %s" % (moves))
         moves_out = []
         for move in moves:
             moves_out.append(TrapezoidalMove(move))

--- a/klippy/extras/load_cell_probe.py
+++ b/klippy/extras/load_cell_probe.py
@@ -398,7 +398,7 @@ class TapAnalysis(object):
         for move in moves:
             moves_out.append(TrapezoidalMove(move))
             # DEBUG: enable to see trapq contents
-            # logging.info("trapq move: %s" % (moves_out[-1].to_dict(),))
+            logging.info("trapq move: %s" % (moves_out[-1].to_dict(),))
         num_moves = len(moves_out)
         if num_moves < 5 or num_moves > 6:
             raise self.printer.command_error(


### PR DESCRIPTION
Caught a problem when the error "Expected tap to be 5 to 6 moves long was 7" kept raising when building the bed height map


I dug into the logs and got 2 scenarios: 
In the first one I was able to check this point

```
moves = [
 # acceleration move
    {'print_time': 46.50844275833334,  'move_t': 0.0033333333333333335, 'start_v': 0.0, 'accel': 300.0,   'start_z': 5.0,                   'z_r': -1.0}, 
# 'coasting' move
    {'print_time': 46.51177609166667,  'move_t': 4.951247983333332,     'start_v': 1.0, 'accel': 0.0,     'start_z': 4.998333333333333,     'z_r': -1.0},  
#  halting
    {'print_time': 51.463024075,       'move_t': 0.0,                   'start_v': 0.0, 'accel': 0.0,     'start_z': 0.2999999999997316,    'z_r': 0.0},   
# accel
    {'print_time': 51.64992813333334,  'move_t': 0.0006666666666666668, 'start_v': 0.0, 'accel': 300.0,   'start_z': 0.2999999999997316,    'z_r': 1.0},   
# 'coasting' move bed down
    {'print_time': 51.65059480000001,  'move_t': 1.4993333333333336,    'start_v': 0.2, 'accel': 0.0,     'start_z': 0.30006666666639825,   'z_r': 1.0},   
# deccel
    {'print_time': 53.14992813333334,  'move_t': 0.0006666666666666668, 'start_v': 0.2, 'accel': -300.0,  'start_z': 0.599933333333065,     'z_r': 1.0}    
]
```

In the second one I've got an error
```
moves = [
# accel
    {'print_time': 55.63597359166667,  'move_t': 0.0033333333333333335, 'start_v': 0.0, 'accel': 300.0,   'start_z': 5.0,                   'z_r': -1.0}, 
# 'coasting' move
    {'print_time': 55.639306925,       'move_t': 4.996666666666666,     'start_v': 1.0, 'accel': 0.0,     'start_z': 4.998333333333333,     'z_r': -1.0}, 
# deccel
    {'print_time': 60.63597359166667,  'move_t': 0.0033333333333333335, 'start_v': 1.0, 'accel': -300.0,  'start_z': 0.0016666666666669272, 'z_r': -1.0}, 
# halting
    {'print_time': 60.67597359166639,  'move_t': 0.0,                   'start_v': 0.0, 'accel': 0.0,     'start_z': 0.2195312499994646,    'z_r': 0.0},  
# accel
    {'print_time': 60.695973591666394, 'move_t': 0.0006666666666666668, 'start_v': 0.0, 'accel': 300.0,   'start_z': 0.2195312499994646,    'z_r': 1.0}, 
#  'coasting' move bed down
    {'print_time': 60.69664025833306,  'move_t': 1.4993333333333336,    'start_v': 0.2, 'accel': 0.0,     'start_z': 0.21959791666613127,   'z_r': 1.0}, 
# deccel
    {'print_time': 62.195973591666394, 'move_t': 0.0006666666666666668, 'start_v': 0.2, 'accel': -300.0,  'start_z': 0.519464583332798,     'z_r': 1.0} 
]
```

I've refactored logic for `_recalculate_homing_end`. Now it uses not hardcoded positions for moves, but trying to find this moves by specified criteria.  
Tested on my k1c and now height map works